### PR TITLE
feat: anonymous migration

### DIFF
--- a/config/translation.php
+++ b/config/translation.php
@@ -67,9 +67,6 @@ return [
     |
     */
     'database' => [
-
-        'connection' => '',
-
         'languages_table' => 'languages',
 
         'translations_table' => 'translations',

--- a/database/migrations/2018_08_29_200844_create_languages_table.php
+++ b/database/migrations/2018_08_29_200844_create_languages_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use JoeDixon\Translation\Language;
 
-class CreateLanguagesTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -15,13 +15,12 @@ class CreateLanguagesTable extends Migration
      */
     public function up()
     {
-        Schema::connection(config('translation.database.connection'))
-            ->create(config('translation.database.languages_table'), function (Blueprint $table) {
-                $table->increments('id');
-                $table->string('name')->nullable();
-                $table->string('language');
-                $table->timestamps();
-            });
+        Schema::create(config('translation.database.languages_table'), function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->string('language');
+            $table->timestamps();
+        });
 
         $initialLanguages = array_unique([
             config('app.fallback_locale'),
@@ -42,7 +41,6 @@ class CreateLanguagesTable extends Migration
      */
     public function down()
     {
-        Schema::connection(config('translation.database.connection'))
-            ->dropIfExists(config('translation.database.languages_table'));
+        Schema::dropIfExists(config('translation.database.languages_table'));
     }
-}
+};

--- a/database/migrations/2018_08_29_205156_create_translations_table.php
+++ b/database/migrations/2018_08_29_205156_create_translations_table.php
@@ -5,7 +5,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTranslationsTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -14,17 +14,16 @@ class CreateTranslationsTable extends Migration
      */
     public function up()
     {
-        Schema::connection(config('translation.database.connection'))
-            ->create(config('translation.database.translations_table'), function (Blueprint $table) {
-                $table->increments('id');
-                $table->unsignedInteger('language_id');
-                $table->foreign('language_id')->references('id')
-                    ->on(config('translation.database.languages_table'));
-                $table->string('group')->nullable();
-                $table->text('key');
-                $table->text('value')->nullable();
-                $table->timestamps();
-            });
+        Schema::create(config('translation.database.translations_table'), function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('language_id');
+            $table->foreign('language_id')->references('id')
+                ->on(config('translation.database.languages_table'));
+            $table->string('group')->nullable();
+            $table->text('key');
+            $table->text('value')->nullable();
+            $table->timestamps();
+        });
     }
 
     /**
@@ -34,7 +33,6 @@ class CreateTranslationsTable extends Migration
      */
     public function down()
     {
-        Schema::connection(config('translation.database.connection'))
-            ->dropIfExists(config('translation.database.translations_table'));
+        Schema::dropIfExists(config('translation.database.translations_table'));
     }
-}
+};


### PR DESCRIPTION
- Apply anonymous migration to resolve migration class name conflict (Laravel >8.37 is required)
- Database connection to follow .env instead of translations.php (To avoid running on mysql connection when sqlite is used)